### PR TITLE
Use site.Menus.main in goal cards

### DIFF
--- a/content/news/_index.md
+++ b/content/news/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "News"
 name: "News"
+bg_image: "images/banners/lake.jpg"
 menu:
   main:
     parent: 'About'

--- a/layouts/partials/cards.html
+++ b/layouts/partials/cards.html
@@ -1,5 +1,41 @@
 <div class = "cards">
-  {{ range .Pages }}
+
+  {{ $currentPage := . }}
+  {{ $menu := site.Menus.main }}
+
+  {{/* If any of the child pages of this page are menu items, then this is a top-level section overview page. */}}
+
+  {{ $isOverviewPage := false }}
+  {{ $menuSection := false }}
+
+  {{ range $menuItem := $menu }}
+    {{ range $menuItemChild := $menuItem.Children }}
+      {{ range $sectionPage := $currentPage.Pages }}
+        {{ if eq $sectionPage $menuItemChild.Page }}
+          {{ $isOverviewPage = true }}
+          {{ $menuSection = $menuItem }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+
+  {{/* If this page is a section overview, then show cards for all the child items in the menu. */}}
+  {{/* If this is another type of index page, then just show cards for the child pages.  */}}
+
+  {{ $pages := slice }}
+
+  {{ if $isOverviewPage }}
+    {{ range $menuItemChild := $menuSection.Children }}
+        {{/* Do not add a card for the currentPage */}}
+        {{ if not (eq $currentPage $menuItemChild.Page) }}
+          {{ $pages = $pages | append $menuItemChild.Page }}
+        {{ end }}
+      {{ end }}
+  {{ else }}
+    {{ $pages = .Pages }}
+  {{ end }}
+
+  {{ range $pages }}
     {{if .Params.bg_image }}
       {{ if not (fileExists (string .Params.bg_image)) }}
         {{ errorf "Failed to generate card image because the following file was not found." .Params.bg_image }}


### PR DESCRIPTION
This PR adds logic to the cards template that checks whether or not the current page is one of the five overview pages in the menu (i.e. the first item in each menu dropdown).

The cards template checks if the current page is an overview page by checking whether some of the current page's sub-pages (`.Pages`) are also menu items in the main menu.

If the current page is an overview page, then the cards template shows cards for all of the child pages that are in the same menu section. If the current page is _not_ an overview page, then the cards template shows cards for the child `.Pages` as it did before.

This resolves the issue where pages which were in the same menu section but were not in the same content directory were not listed in the cards navigation: the goals page was missing from methodology, and the news page was missing from about.

Fixes #56