### PR TITLE
Add a navigation bar under the main banner

### DIFF
--- a/assets/scss/partials/top-nav.scss
+++ b/assets/scss/partials/top-nav.scss
@@ -1,0 +1,17 @@
+.nav.top-nav {
+  color: grey;
+}
+
+.top-nav-item {
+  color: grey;
+  text-decoration: none;
+  padding-right: 0.5rem;
+}
+.top-nav-item:visited {
+  color: grey;
+}
+
+.top-nav-item.current{
+  color:$text-color-dark;
+  font-weight: bold;
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -14,6 +14,7 @@
 @import 'partials/logo.scss';
 @import 'partials/news.scss';
 @import 'partials/page-header.scss';
+@import 'partials/top-nav.scss';
 @import 'about/publications.scss';
 @import 'shortcodes/csv-table.scss';
 @import 'data-viz/_main';

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -6,9 +6,9 @@
     {{- partial "nav.html" . -}}
     {{- if not .IsHome -}}
       {{- partial "page-header.html" . -}}
+      {{- partial "top-nav.html" . -}}
     {{- end -}}
     {{- block "main" . -}}{{- end -}}
-
     {{- with resources.Get "js/main.js" -}}
       
       {{/* dataConfig: JSON with paths to all of the OHI data files, plus other data config properties. See content/data/_index.md */}}

--- a/layouts/partials/top-nav.html
+++ b/layouts/partials/top-nav.html
@@ -1,0 +1,16 @@
+<div  class="nav top-nav">
+  {{ template "breadcrumbnav" (dict "p1" . "p2" . "current" .) }}
+</div>
+
+{{ define "breadcrumbnav" }}
+  {{ if .p1.Parent }}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Parent "p2" .p2 "current" .current)  }}
+  {{ else if not .p1.IsHome }}
+    {{ template "breadcrumbnav" (dict "p1" .p1.Site.Home "p2" .p2 )  }}
+  {{ end }}
+  {{if eq .p1.Title .current.Title }}
+  <a class = "top-nav-item current" href="{{ .p1.Permalink }}">&nbsp{{ .p1.Title }}</a>
+  {{ else }}
+  <a class = "top-nav-item" href="{{ .p1.Permalink }}">&nbsp{{ .p1.Title }}</a> >
+  {{end}}
+{{ end }}


### PR DESCRIPTION
This PR adds a navigation menu to pages that aren't the main home page. It appears underneath the banner, but above the three columns. One piece that may or may not be intuitive is that since the 'Goals' page isn't a subpage of 'Methodology', but is in the browser-the 'Methodology' part is left out in the navigation.

To Do:
- [ ] Align with the left column
- [ ] `Goals > xyz` vs `Methodology > Goals > xyz`
