### PR TITLE
Remove 'float' properties from main page layout and use grid

### DIFF
--- a/assets/scss/partials/layout/center-col.scss
+++ b/assets/scss/partials/layout/center-col.scss
@@ -1,15 +1,10 @@
 .column-center {
-
-  --col-width: 60%;
-
-  width: var(--col-width);
-  float: left;
   border-bottom: 1px solid rgba(30,44,94,.2);
 
   &__full-width-container{
     --padding: 5%;
-    margin-left: calc( (var(--col-width)/2 * -1) + var(--padding) );
-    width: calc(100% + var(--col-width) - (2 * var(--padding)));
+    margin-left: calc( (var(60%)/2 * -1) + var(--padding) );
+    width: calc(100% + var(60%) - (2 * var(--padding)));
   }
 }
 

--- a/assets/scss/partials/layout/layout.scss
+++ b/assets/scss/partials/layout/layout.scss
@@ -1,0 +1,4 @@
+.default-section{
+  display: grid;
+  grid-template-columns: 20% auto 20%;
+}

--- a/assets/scss/partials/layout/layout.scss
+++ b/assets/scss/partials/layout/layout.scss
@@ -1,4 +1,6 @@
 .default-section{
   display: grid;
-  grid-template-columns: 20% auto 20%;
+  grid-template-columns: 12% auto 16%;
+  gap: 3rem;
+  padding: 2rem;
 }

--- a/assets/scss/partials/layout/left-col.scss
+++ b/assets/scss/partials/layout/left-col.scss
@@ -1,6 +1,4 @@
 .column-left {
-  width: 20%;
-  float: left;
   position: relative;
 
   &__title {
@@ -12,10 +10,8 @@
   }
 
   &__logo {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    min-height: 6rem;
-    top: -0.5rem;
+    position: relative;
+    width: 10rem;
+    top: -8.5rem;
   }
 }

--- a/assets/scss/partials/layout/right-col.scss
+++ b/assets/scss/partials/layout/right-col.scss
@@ -1,11 +1,7 @@
 .column-right {
-  width: 20%;
-  float: left;
 }
 
 .column-right {
-  width: 15%;
-  float: left;
   padding-left: 1rem;;
 }
 

--- a/assets/scss/partials/layout/right-col.scss
+++ b/assets/scss/partials/layout/right-col.scss
@@ -1,5 +1,4 @@
 .column-right {
-  padding-left: 1rem;;
 }
 
 .right-col-nav {

--- a/assets/scss/partials/layout/right-col.scss
+++ b/assets/scss/partials/layout/right-col.scss
@@ -1,7 +1,4 @@
 .column-right {
-}
-
-.column-right {
   padding-left: 1rem;;
 }
 

--- a/assets/scss/partials/top-nav.scss
+++ b/assets/scss/partials/top-nav.scss
@@ -1,5 +1,9 @@
-.nav.top-nav {
+.top-nav {
   color: grey;
+  display: flex;
+  padding-top: 1rem;
+  padding-left: 4rem;
+  padding-bottom: 1rem;
 }
 
 .top-nav-item {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -9,6 +9,7 @@
 @import 'partials/layout/center-col.scss';
 @import 'partials/layout/left-col.scss';
 @import 'partials/layout/right-col.scss';
+@import 'partials/layout/layout.scss';
 @import 'partials/footer.scss';
 @import 'partials/cards.scss';
 @import 'partials/logo.scss';

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,8 @@
 {{ define "main" }}
-  <section class="section">
+  <section class="default-section">
     {{- partial "layout/left-col.html" . -}}
     {{- partial "layout/center-col.html" . -}}
     {{- partial "layout/right-col.html" . -}}
-    {{- partial "cards.html" . -}}
   </section>
+  {{- partial "cards.html" . -}}
 {{end}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <section class="section">
+  <section class="default-section">
   {{- partial "layout/left-col.html" . -}}
   {{- partial "layout/center-col.html" . -}}
   {{- partial "layout/right-col.html" . -}}

--- a/layouts/partials/top-nav.html
+++ b/layouts/partials/top-nav.html
@@ -1,4 +1,4 @@
-<div  class="nav top-nav">
+<div  class="top-nav">
   {{ template "breadcrumbnav" (dict "p1" . "p2" . "current" .) }}
 </div>
 


### PR DESCRIPTION
This Pr introduces some changes to remove the 'float' properties from the main page layout. 


## Changes
assets/scss/partials/layout/center-col.scss no longer holds the responsibility for setting its width. Refer to assets/scss/partials/layout/layout.scss to see the 20% change.

assets/scss/partials/layout/layout.scss  is a new layout file that defines the grid properties for the 3-column layout.

assets/scss/partials/layout/left-col.scss No longer sets its own width. I was able to get rid of the absolute positioning and simplify the other properties for the logo.

assets/scss/partials/top-nav.scss I was able to make the styling closer to the original by putting a gap between the banner and the nav (top padding). The bottom padding is to give a little barrier between it and the left column section.

layouts/_default/list.html I pulled the cards out of this so that it isn't constrained by the new grid layout
