### PR TITLE
Add development deployment

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,39 @@
+name: Deploy Preview
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true  # Fetch Hugo themes (true OR recursive)
+          fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: 'latest'
+          extended: true
+      - name: Build
+        run: |
+          npm install
+          hugo --baseURL="http://preview.oceanhealthindex.org/"
+      # Copy the source to the nceas server
+      - name: Copy
+        uses: siva1024/scp-deployer@latest
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USER }}
+          pass: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          source: "public/"
+          target: ${{ secrets.DEPLOY_PATH_DEV }}
+          key: ${{ secrets.KEY }}
+          rm: true


### PR DESCRIPTION
This pull request adds an action on the `dev` branch that, when pushed to, will build and deploy the site located at `preview.oceanhealthidex.org`.

To test:
1. Visit `preview.oceanhealthidex.org`
2. Make sure that you see the site deployed
3. Check that the [action](https://github.com/OHI-Science/OHI-website/actions/runs/1387148844) was a success 