### PR TITLE
Change the production OHI URL

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         run: |
           npm install
-          hugo --baseURL="http://dev.oceanhealthindex.org/"
+          hugo --baseURL="http://oceanhealthindex.org/"
       # Copy the source to the nceas server
       - name: Copy
         uses: dataoneorg/rsync-deploy@latest


### PR DESCRIPTION
This PR changes the default production URL to oceanhealthindex.org instead of dev.oceanhealthindex.org